### PR TITLE
PODC-334: Remove Missing Columns & Fix Bad Variable Ref

### DIFF
--- a/models/page_views/bigquery/snowplow_page_views.sql
+++ b/models/page_views/bigquery/snowplow_page_views.sql
@@ -120,56 +120,18 @@ page_views as (
         when refr_medium = 'unknown' then 'other'
         else refr_medium
       end as medium,
-      refr_source as source,
-      refr_term as term
+      refr_source as source
     ) as referer,
 
     struct(
-      mkt_medium as medium,
-      mkt_source as source,
-      mkt_term as term,
-      mkt_content as content,
-      mkt_campaign as campaign,
-      mkt_clickid as click_id,
-      mkt_network as network
+      mkt_source as source
     ) as marketing,
 
     struct(
-      user_ipaddress as ip_address,
-      ip_isp as isp,
-      ip_organization as organization,
-      ip_domain as domain,
-      ip_netspeed as net_speed
+      user_ipaddress as ip_address
     ) as ip,
 
-    struct(
-      geo_city as city,
-      geo_country as country,
-      geo_latitude as latitude,
-      geo_longitude as longitude,
-      geo_region as region,
-      geo_region_name as region_name,
-      geo_timezone as timezone,
-      geo_zipcode as zipcode
-    ) as geo,
-
-    struct(
-      os_family as family,
-      os_manufacturer as manufacturer,
-      os_name as name,
-      os_timezone as timezone
-    ) as os,
-
     br_lang as browser_language,
-
-    -- TODO : useragent
-    -- TODO : perf_timing
-
-    struct(
-        br_renderengine as browser_engine,
-        dvce_type as type,
-        dvce_ismobile as is_mobile
-    ) as device
     
     {%- if var('snowplow:pass_through_columns') | length > 0 %}
     , struct(
@@ -179,7 +141,6 @@ page_views as (
 
   from events
   where event = 'page_view'
-    and (br_family != 'Robot/Spider' or br_family is null)
     and (
         {% set bad_agents_psv = bot_any()|join('|') %}
         not regexp_contains(LOWER(useragent), '^.*({{bad_agents_psv}}).*$')

--- a/models/sessions/bigquery/snowplow_sessions_tmp.sql
+++ b/models/sessions/bigquery/snowplow_sessions_tmp.sql
@@ -6,8 +6,7 @@
             'data_type': 'timestamp'
         },
         unique_key='session_id',
-        cluster_by='session_id',
-        enabled=is_adapter('bigquery')
+        cluster_by='session_id'
     )
 }}
 
@@ -85,12 +84,9 @@ sessions as (
     first_page_view.user_custom_id,
     first_page_view.user_snowplow_domain_id,
     first_page_view.user_snowplow_crossdomain_id,
-
     first_page_view.session_id,
     first_page_view.session_index,
-
     first_page_view.app_id,
-
     timing.session_start,
     timing.session_end,
     array_length(all_pageviews) as count_page_views,
@@ -115,13 +111,10 @@ sessions as (
 
     first_page_view.referer as referer,
     first_page_view.marketing as marketing,
-    first_page_view.geo as geo,
     first_page_view.ip as ip,
     first_page_view.browser as browser,
-    first_page_view.os as os,
-    first_page_view.device as device,
     
-    {% if var('snowplow:pass_through_columns') | length > 0 %}
+    {% if var('snowplow_pass_through_columns', []) | length > 0 %}
     first_page_view.custom as first_custom,
     exit_page_view.custom as last_custom,
     {% endif %}


### PR DESCRIPTION
## Description & motivation
In order to get the `dbt-labs/snowplow` package working for us, there were two issues that required fixes: 

- Removing columns referenced in the package models that our Snowplow data didn't have upstream. 
- Fixing an issue where leaving the `snowplow_pass_through_columns` empty caused the model to break 

Generally, we should be able to override package defaults by making an exact copy of the package model and then disabling it in our `dbt_project.yml` file (https://hub.getdbt.com/dbt-labs/snowplow/latest/): 
![image](https://user-images.githubusercontent.com/50755445/214181543-caa25524-ffde-4787-8160-88d442042077.png)

However, I couldn't seem to get that option working after fiddling with it for quite a while: 
![image](https://user-images.githubusercontent.com/50755445/214183323-ca4c1899-3e95-435f-b5b8-5997d820c84b.png)

Hence, this brings us to the second option: making a fork and implementing the changes there.