### PR TITLE
PODC-787: Remove ephemeral materialization

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,7 +25,3 @@ vars:
   'snowplow:pass_through_columns': []
   'snowplow:page_view_lookback_days': 1
 
-models:
-  snowplow:
-    base:
-      +materialized: ephemeral


### PR DESCRIPTION
## Description
This PR fixes some odd issues we've recently observed with our dbt tests, see: 

- https://gitlab.com/packback/data-engineering/-/pipelines/928147114
- https://airflow.packback.co/log?dag_id=ci_dbt_deployments&task_id=test_dbt_models&execution_date=2023-07-11T14%3A50%3A00%2B00%3A00&map_index=-1

This package effectively acts as library code for our dbt project that encapsulates much of the necessary complexity to transform raw snowplow events into useful tables like `page_views` and `sessions`. As such, the models that are created by this package are not explicitly assigned a dataset and get defaulted to `should_not_be_used` -- this is _mostly_ fine since we have no direct use for any of these models and can simply let them get deployed in the background without being assigned to a particular dataset. Our `models/snowplow_events/` dataset will automatically build from these package-specific tables without needing to assign them to a dataset. 

The current configuration specifies an `ephemeral` materialization strategy. This may seem fine for our purposes but has an unexpected complication: our unit tests expect that the package-specific tables exist in the `should_not_be_used` dataset and an ephemeral reference is not acceptable (if it can't find the upstream tables, it will fail). See: https://github.com/EqualExperts/dbt-unit-testing/issues/149 -- other folks have also seemed to notice this is not supported.

## Testing
I tested this changes by manually modifying the package code locally in `dbt_config/dbt_packages/snowplow/dbt_project.yml` and then running: 

- `dbt run -m snowplow`
- `dbt test -m tests/unit/snowplow_events__page_views_tagged_pages.sql` 

After re-deploying the Snowplow models and re-running the unit tests, the issue appeared to be resolved.

![image](https://github.com/dbt-labs/snowplow/assets/50755445/497f5b4e-71f1-43fb-9669-c99ba06cdf04)

![image](https://github.com/dbt-labs/snowplow/assets/50755445/27dfcce0-98e2-4bb8-a38a-7d90444e12ba)

