### PR TITLE
ENG-6357: Fix start ts (fingers crossed)

### DIFF
--- a/macros/adapters/get_start_ts.sql
+++ b/macros/adapters/get_start_ts.sql
@@ -5,7 +5,7 @@
         
         coalesce(
             max({{field}}), 
-            '0001-01-01'    -- a long, long time ago
+            '1970-01-01'    -- a long, long time ago
         ) as start_ts
         
     from {{ relation }}


### PR DESCRIPTION
Currently the fallback date is set too early, anytime a day is subtracted from `0001-01-01` (like in: https://github.com/packbackbooks/dbt-snowplow-utils/blob/97253870799a61ac015b57ff17fa32d2baadc476/models/page_views/default/snowplow_page_views.sql#L26-L31) an overflow error is raised: https://gitlab.com/packback/data-engineering/-/jobs/11867295087

This is now occurring because w/ the new alias system snowplow models are built from scratch which results in null values 9which results in the default date) 